### PR TITLE
Adds docs for `optIn` and `progressiveMode`

### DIFF
--- a/docs/topics/enum-classes.md
+++ b/docs/topics/enum-classes.md
@@ -119,7 +119,7 @@ printAllValues<RGB>() // prints RED, GREEN, BLUE
 > 
 > {type="tip"}
 
-In Kotlin 1.8.20, the `entries` property is introduced as a future replacement for the `values()` function. The 
+In Kotlin 1.9.0, the `entries` property is introduced as a replacement for the `values()` function. The 
 `entries` property returns a pre-allocated immutable list of your enum constants. This is particularly useful when you 
 are working with [collections](collections-overview.md) and can you help you avoid [performance issues](https://github.com/Kotlin/KEEP/blob/master/proposals/enum-entries.md#examples-of-performance-issues).
 
@@ -127,17 +127,11 @@ For example:
 ```kotlin
 enum class RGB { RED, GREEN, BLUE }
 
-@OptIn(ExperimentalStdlibApi::class)
 fun main() {
     for (color in RGB.entries) println(color.toString())
     // prints RED, GREEN, BLUE
 }
 ```
-
-> The `entries` property is Experimental. To use it, opt in with `@OptIn(ExperimentalStdlibApi)`, and
-> [set the language version to 1.9](gradle-compiler-options.md#attributes-common-to-jvm-and-js).
->
-{type="warning"}
 
 Every enum constant also has properties: [`name`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-enum/name.html)
 and [`ordinal`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-enum/ordinal.html), for obtaining its name and 

--- a/docs/topics/gradle/gradle-compiler-options.md
+++ b/docs/topics/gradle/gradle-compiler-options.md
@@ -116,6 +116,13 @@ tasks.named('compileKotlin', KotlinCompilationTask) {
 
 Here is a complete list of options for Gradle tasks:
 
+### Common attributes
+
+| Name              | Description                                     | Possible values           | Default value |
+|-------------------|-------------------------------------------------|---------------------------|---------------|
+| `optIn`           | Property to configure opt-in compiler arguments | `listOf( /* opt-ins */ )` | `emptyList()` |
+| `progressiveMode` | Enable progressive compiler mode                | `true`, `false`           | `false`       |
+
 ### Attributes specific to JVM
 
 | Name | Description | Possible values |Default value |
@@ -155,9 +162,9 @@ val compileKotlin: KotlinCompilationTask<*> by tasks
 // Single experimental argument
 compileKotlin.compilerOptions.freeCompilerArgs.add("-Xexport-kdoc")
 // Single additional argument, can be a key-value pair
-compileKotlin.compilerOptions.freeCompilerArgs.add("-opt-in=org.mylibrary.OptInAnnotation")
+compileKotlin.compilerOptions.freeCompilerArgs.add("-Xno-param-assertions")
 // List of arguments
-compileKotlin.compilerOptions.freeCompilerArgs.addAll(listOf("-Xno-param-assertions", "-Xno-receiver-assertions", "-Xno-call-assertions"))
+compileKotlin.compilerOptions.freeCompilerArgs.addAll(listOf("-Xno-receiver-assertions", "-Xno-call-assertions"))
 ```
 
 </tab>
@@ -172,9 +179,9 @@ tasks.named('compileKotlin', KotlinCompilationTask) {
         // Single experimental argument
         freeCompilerArgs.add("-Xexport-kdoc")
         // Single additional argument, can be a key-value pair
-        freeCompilerArgs.add("-opt-in=org.mylibrary.OptInAnnotation")
+        freeCompilerArgs.add("-Xno-param-assertions")
         // List of arguments
-        freeCompilerArgs.addAll(["-Xno-param-assertions", "-Xno-receiver-assertions", "-Xno-call-assertions"])
+        freeCompilerArgs.addAll(["-Xno-receiver-assertions", "-Xno-call-assertions"])
     }
 }
 ```


### PR DESCRIPTION
- update: make Enum.entries Stable
- Adds docs for `optIn` and `progressiveMode`
